### PR TITLE
Prevent crashes upon using @query and echo together

### DIFF
--- a/desktop/server/actions/echo.js
+++ b/desktop/server/actions/echo.js
@@ -13,7 +13,7 @@ function Echo (host) {
       return errors.NOPARAM()
     }
 
-    const reaction_rendered = this.render(params, params, host)
+    const reaction_rendered = this.render(params, null, host) // query = null
     return `<p>${reaction_rendered}</p>`
   }
 }

--- a/desktop/server/core/wildcard.js
+++ b/desktop/server/core/wildcard.js
@@ -104,10 +104,10 @@ function Wildcard (host, input, query, responder) {
 
     // Programming
     query: function () {
-      return query
+      return query ? query : helpers.nil
     },
     responder: function () {
-      return responder.id
+      return responder ? responder.id : helpers.nil
     },
     success: function () {
       return !host.data.last_error ? 'true' : helpers.nil


### PR DESCRIPTION
Caused by recursion of @query returning another instance of @query, which was then evaluated as @query, etc. until crash.